### PR TITLE
refactor thumbnail display to grid layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -313,39 +313,37 @@ fetch('data/points.json')
       const cont = document.getElementById('image-container');
       cont.innerHTML = '';
 
-      const urls  = record[getThumbKey(currentThumbDataset)] || [];
-      const dates = record[getDatesKey(currentThumbDataset)] || [];  
+      const urls  = (record[getThumbKey(currentThumbDataset)] || []).slice(0, 4);
+      const dates = (record[getDatesKey(currentThumbDataset)] || []).slice(0, 4); 
 
       /*show all urls; label from dates if present at same index*/
       urls.forEach((url, i) => {
         if (!url) return;
 
         const card = document.createElement('div');
-        card.style.textAlign = 'center';
-        card.style.marginBottom = '8px';
+        card.className = 'thumb-card';
 
         const img = document.createElement('img');
         img.src = url;
+        img.className = 'thumb-img';
 
-        if (currentThumbDataset === 'landsat') {
+        /* uniform size & position */
         img.style.width  = '96px';
         img.style.height = '96px';
-        img.style.objectFit = 'contain';
-        /* nearest-neighbor*/ 
-        img.style.imageRendering = 'pixelated';
-        /*center the small fixed-size image*/
         img.style.display = 'block';
-        img.style.margin = '0 auto';
+        img.style.margin  = '0 auto';   /* center in the grid cell*/
+        img.style.objectFit = 'contain'; /*keep full image visible*/
+
+        if (currentThumbDataset === 'landsat') {
+          img.style.imageRendering = 'pixelated';
         } else {
-        /*for S1/S2*/
-        img.style.width = '100%';
-        img.style.maxHeight = '180px';}
+          /*s1 s2*/
+          img.style.imageRendering = '';
+        }
 
         const lbl = document.createElement('p');
+        lbl.className = 'thumb-label';
         lbl.textContent = (dates[i] ?? '').toString();
-        lbl.style.color = 'white';
-        lbl.style.margin = '4px 0 0';
-        lbl.style.fontSize = '0.9em';
 
         card.appendChild(img);
         card.appendChild(lbl);

--- a/styles.css
+++ b/styles.css
@@ -159,24 +159,32 @@ html, body {margin:0; padding:0; height:100%; overflow: hidden;}
 }
 
   #image-container {
-    flex: 7;  
-    display: flex;   /* switch from grid to a one-row flex strip */
-    flex-wrap: nowrap;
-    align-items: flex-start;
-    gap: 6px;
-    padding: 4px; margin: 0;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+    padding: 8px;
+    margin: 0;
     box-sizing: border-box;
-    overflow-x: auto;    /* horizontal scroll for many thumbnails */
-    overflow-y: hidden;
+    overflow: hidden;
   }
 
-  #image-container img {
-  display: block; 
-  width: 100%;
-  height: auto;
-  flex: 0 0 auto;    
-  margin: 0;
-  border: 0;
+  .thumb-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  /* default for S1/S2 */
+  .thumb-img {
+    display: block;
+    border: 0;
+  }
+
+  .thumb-label {
+    color: #fff;
+    margin: 4px 0 0;
+    font-size: 0.9em;
+    text-align: center;
   }
 
   #footer {


### PR DESCRIPTION
Changed thumbnail rendering from a horizontal flex strip to a 4-column grid for improved layout. Added CSS classes for thumbnail cards, images, and labels, and limited displayed thumbnails to four per record. Updated styling for better alignment and appearance.

Issue #7 