### PR TITLE
Add Home control to reset map view

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,6 +96,42 @@ fetch('data/points.json')
       }
     });
   }
+
+    function resetMapViewToDefaults() {
+
+      highlightIdsOnMap(new Set());
+      clearPlotSelections();
+
+      if (!map) return;
+
+      /* pick this mode’s defaults*/
+      const { center, zoom, projection } = presets[currentMode] || presets.globe;
+
+      /* pause the spin */
+      userInteracting = true;
+
+      /* apply padding*/
+      applyPaddingForMode(currentMode);
+
+      /* snap back to the default camera for the current mode*/
+      map.easeTo({
+        center,
+        zoom,
+        bearing: 0,
+        pitch: 0,
+        duration: 800,
+        /* keep the same projection*/
+        essential: true
+      });
+
+      /* re-spin*/
+      const once = () => {
+        map.off('moveend', once);
+        userInteracting = false;
+        spinGlobe();
+      };
+      map.on('moveend', once);
+    }
     
     /*choose image*/
     function wireImageMenu() {
@@ -567,6 +603,33 @@ fetch('data/points.json')
       /*add navigation controls*/
       const navControl = new mapboxgl.NavigationControl();
       map.addControl(navControl, 'top-left');
+
+      /* HOME control */
+      class HomeControl {
+        onAdd(_map) {
+          this._map = _map;
+          const container = document.createElement('div');
+          container.className = 'mapboxgl-ctrl mapboxgl-ctrl-group mapboxgl-ctrl-home';
+
+          const btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'mapboxgl-ctrl-icon';
+          btn.setAttribute('aria-label', 'Reset view');
+          /* house svg to matche mapbox icon style*/
+          btn.innerHTML = `
+            <svg viewBox="0 0 20 20" width="20" height="20" aria-hidden="true">
+              <path d="M10 3 2.5 9h1.8v8h4.2v-5h2v5h4.2V9h1.8L10 3z" />
+            </svg>`;
+          btn.addEventListener('click', resetMapViewToDefaults);
+          container.appendChild(btn);
+          return (this._container = container);
+        }
+        onRemove() {
+          this._container.remove();
+          this._map = undefined;
+        }
+      }
+      map.addControl(new HomeControl(), 'top-left');
 
       /*add selection controls */
       const draw = new MapboxDraw({

--- a/styles.css
+++ b/styles.css
@@ -262,6 +262,24 @@
   z-index: 3;
   }
 
+  /* center the home icon inside the control button */
+    .mapboxgl-ctrl-home .mapboxgl-ctrl-icon {
+      display: flex;                /* center children horizontally & vertically */
+      align-items: center;
+      justify-content: center;
+      padding: 0;                   /* remove extra padding */
+      background-image: none !important;  /* not stack default bg icon */
+    }
+
+    /* size the SVG to sit centered */
+    .mapboxgl-ctrl-home .mapboxgl-ctrl-icon svg {
+      width: 18px;                  
+      height: 18px;
+      display: block;               /* remove baseline gap */
+      pointer-events: none;         /* click passes to the button */
+      fill: currentColor;           /* match Mapbox control color */
+    }
+
   .globe-map {
     position: absolute;
     bottom: 32px;


### PR DESCRIPTION
- Introduces a Home button to the map UI that resets the view to default settings for the current mode. Implements the resetMapViewToDefaults function and integrates the control alongside existing navigation controls.

- Added CSS rules to center the home icon within the Mapbox control button and ensure the SVG is properly sized and styled. This improves visual alignment and consistency with other Mapbox controls.