### PR TITLE
Add Mapbox Satellite basemap into mode selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
       <div class="globe-map">
         <button type="button" onclick="clickFunction('globe', this)">Globe</button>
         <button type="button" onclick="clickFunction('mercator', this)">Map</button>
+        <button type="button" onclick="clickFunction('satellite', this)">Satellite</button>
       </div>
 
       <div id="map-plot"></div>

--- a/script.js
+++ b/script.js
@@ -385,7 +385,7 @@ Promise.all([
     let spinEnabled = true;           /* enabled only in globe*/
 
     function spinGlobe() {
-      if (!map || !spinEnabled || currentMode !== 'globe') return;
+      if (!map || !spinEnabled || (currentMode !== 'globe' && currentMode !== 'satellite')) return;
       const zoom = map.getZoom();
       if (zoom >= maxSpinZoom || userInteracting) return;
 
@@ -422,11 +422,13 @@ Promise.all([
 
     const styles = {
       globe:    'mapbox://styles/clarkcga/cmippxwrj00cm01s7a7zx9sq3',
-      mercator: 'mapbox://styles/clarkcga/cmippf1iz00ck01s7cgt3fe1u'
+      mercator: 'mapbox://styles/clarkcga/cmippf1iz00ck01s7cgt3fe1u',
+      satellite: 'mapbox://styles/clarkcga/cml13h7oc00gi01qr5ubrh949',
     };
     const presets = {
       globe:    { projection: 'globe',    center: [31, 30], zoom: 2   },
-      mercator: { projection: 'mercator', center: [28, 20], zoom: 1.7 }
+      mercator: { projection: 'mercator', center: [28, 20], zoom: 1.7 },
+      satellite:    { projection: 'globe',    center: [31, 30], zoom: 2   },
     };
 
     /* build plotly traces and an id → index for quick selection*/
@@ -1323,7 +1325,7 @@ Promise.all([
       /* total right padding = panel width + legend width*/
       const rightPad = getSideWidthPx() + getLegendWidthPx();
 
-      if (mode === 'globe') {
+      if (mode === 'globe' || mode === 'satellite') {
         const rightPad = getSideWidthPx();
         /* set padding so the globe appears centered left*/
         map.setPadding({ top: 0, right: rightPad, bottom: 0, left: 0 });
@@ -1339,8 +1341,8 @@ Promise.all([
       if (map) { try { map.remove(); } catch {} map = null; }
 
       currentMode = mode;
-      /* spin only for globe */
-      spinEnabled = (mode === 'globe');
+      /* spin only for globe and satellite */
+      spinEnabled = (mode === 'globe' || mode === 'satellite');
 
       map = new mapboxgl.Map({
         container: 'map-plot',
@@ -1388,7 +1390,7 @@ Promise.all([
         .forEach(b => b.classList.toggle('active', b === btnEl));
       
 
-      spinEnabled = (mode === 'globe');
+      spinEnabled = (mode === 'globe' || mode === 'satellite');
       /* rebuild the chosen mode*/
       buildMap(mode);
 

--- a/script.js
+++ b/script.js
@@ -338,8 +338,12 @@ Promise.all([
       ];
       
       /* control fill opacity per feature */
-      const SELECTED_FILL_OPACITY = 1.0;
-      const UNSELECTED_FILL_OPACITY = 0.20; 
+      const SELECTED_FILL_OPACITY = currentMode === 'satellite' ? 0.20 : 1.0;
+      const UNSELECTED_FILL_OPACITY = 0.20;
+
+      /* control centroid opacity per feature */
+      const SELECTED_CENTROID_OPACITY = currentMode === 'satellite' ? 0.01 : 1.0;
+      const UNSELECTED_CENTROID_OPACITY = 0.01;
 
       /* make expression that normalizes whichever id property exists on the polygon */
       const idExpr = ['to-string',
@@ -357,8 +361,8 @@ Promise.all([
 
       const centroidOpacityExpr = [
         'case',
-          ['in', idExpr, ['literal', arr]], 1, 
-          0.01
+          ['in', idExpr, ['literal', arr]], SELECTED_CENTROID_OPACITY, 
+          UNSELECTED_CENTROID_OPACITY
       ];
 
       /* Apply expressions */


### PR DESCRIPTION
1. Add Satellite button in "globe-map" class in `index.html`
2. Extended map functionality to include a 'satellite' mode alongside 'globe' and 'mercator'. Updated spin logic, styles, and presets to handle the new mode, ensuring consistent behavior and UI adjustments in `script.js`.
3. Updated fill and centroid opacity values to be lower when in 'satellite' mode, improving visual clarity. Opacity expressions now use these dynamic values based on the current mode in `script.js`.