### PR TITLE
Update model dropdown labels and gfm IDs

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,14 +79,15 @@
             <i class="fa fa-caret-down"></i>
           </button>
           <div class="dropdown-content" id="model-menu">
-            <a href="#" gfm="prithvieov2300m_allpatchesfromapriltojune">Prithvi-EO-2.0-300m: All Patches from April to June</a>
-            <a href="#" gfm="prithvieov2300m_allstepsofmiddlepatch">Prithvi-EO-2.0-300m: All Steps of Middle Patch</a>
-            <a href="#" gfm="prithvieov2300m_clstoken">Prithvi-EO-2.0-300m: Clstoken</a>
-            <a href="#" gfm="prithvieov2600m_allpatchesfromapriltojune">Prithvi-EO-2.0-600m: All Patches from April to June</a>
-            <a href="#" gfm="prithvieov2600m_allstepsofmiddlepatch">Prithvi-EO-2.0-600m: All Steps of Middle Patch</a>
-            <a href="#" gfm="prithvieov2600m_clstoken">Prithvi-EO-2.0-600m: Clstoken</a>
-            <a href="#" gfm="terramindv1base_allpatchesfromapriltojune">Terramindv1base: All Patches from April to June</a>
-            <a href="#" gfm="terramindv1base_allstepsofmiddlepatch">Terramindv1base: All Steps of Middle Patch</a>
+            <a href="#" gfm="exp001_prithvi300_cls_token">Prithvi EO V2 300M: CLS Token</a>
+            <a href="#" gfm="exp001_prithvi300_all_steps_of_middle_patch">Prithvi EO V2 300M: All Steps of Middle Patch</a>
+            <a href="#" gfm="exp001_prithvi300_all_patches_from_april_to_june">Prithvi EO V2 300M: All Patches from April to June</a>
+            <a href="#" gfm="exp004_prithvi600_cls_token">Prithvi EO V2 600M: CLS Token</a>
+            <a href="#" gfm="exp004_prithvi600_all_steps_of_middle_patch">Prithvi EO V2 600M: All Steps of Middle Patch</a>
+            <a href="#" gfm="exp004_prithvi600_all_patches_from_april_to_june">Prithvi EO V2 600M: All Patches from April to June</a>
+            <a href="#" gfm="exp007_terramind_all_steps_of_middle_patch">Terramind V1 Base: All Steps of Middle Patch</a>
+            <a href="#" gfm="exp007_terramind_all_patches_from_april_to_june">Terramind V1 Base: All Patches from April to June</a>
+            <a href="#" gfm="exp007_terramind_all_embeddings">Terramind V1 Base: All Embeddings</a>
           </div>
         </div>
 


### PR DESCRIPTION
Standardize model menu link IDs and display labels in index.html. Replaced legacy gfm keys (prithvieov2300m_*, prithvieov2600m_*, terramindv1base_*) with experiment-style IDs (exp001_prithvi300_*, exp004_prithvi600_*, exp007_terramind_*), updated human-readable names to 'Prithvi EO V2 300M/600M' and 'Terramind V1 Base', added a Terramind embeddings entry, and reordered items for clarity.