### PR TITLE
Show loading overlay during model load 

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,12 @@
     </div>
       
     <div id="right-container">
-      <div id="scatter-plot"></div>
+      <div id="scatter-wrapper" style="position:relative;">
+        <div id="scatter-plot"></div>
+        <div id="scatter-loading" class="scatter-loading-overlay" style="display:none;">
+          <span>Loading data…</span>
+        </div>
+      </div>
       <div id="image-container"></div>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -141,12 +141,17 @@ Promise.all([
       const newModel = link.getAttribute('gfm');
       setModelsButtonLabel(link.textContent.trim());
 
+      /* show loading overlay */
+      const loadingM = document.getElementById('scatter-loading');
+      if (loadingM) loadingM.style.display = 'flex';
+
       /* load model data on-demand */
       try {
         currentModelXY = await loadModelData(newModel);
         currentModel = newModel;
       } catch (err) {
         console.error('Failed to load model data:', err);
+        if (loadingM) loadingM.style.display = 'none';
         return;
       }
 
@@ -164,6 +169,9 @@ Promise.all([
 
       /* keep any highlight/selection visuals consistent after react*/
       Plotly.react('scatter-plot', scatterTraces, scatterLayout, { responsive: true }).then(() => {
+        /* hide loading overlay after plot finishes rendering */
+        if (loadingM) loadingM.style.display = 'none';
+
         // re-apply selection dimming & per-trace selectedpoints
         if (prevHighlightedIds.size > 0) {
           applySelectionToPlot(prevHighlightedIds);
@@ -182,6 +190,10 @@ Promise.all([
             renderThumbnails(rec);
           }
         }
+      }).catch((err) => {
+        /* hide loading overlay even if Plotly.react fails */
+        if (loadingM) loadingM.style.display = 'none';
+        console.error('Plotly.react failed:', err);
       });
     });
     }

--- a/styles.css
+++ b/styles.css
@@ -387,3 +387,23 @@
       color: rgb(204,156,172);
       text-decoration: underline;
   }
+
+/* ---- scatter‑plot loading overlay ---- */
+.scatter-loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+.scatter-loading-overlay span {
+  background: rgba(255, 255, 255, 0.92);
+  color: #333;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+}


### PR DESCRIPTION
Add scatter-loading-overlay on top of plot during model loading. The workflow is: show overlay → fetch data → build traces → Plotly.react → hide overlay